### PR TITLE
fix: Change exception handling to catch all exceptions

### DIFF
--- a/lib/src/asms/better_player_asms_utils.dart
+++ b/lib/src/asms/better_player_asms_utils.dart
@@ -50,7 +50,7 @@ class BetterPlayerAsmsUtils {
       }).asFuture<String?>();
 
       return data;
-    } on Exception catch (exception) {
+    } catch (exception) {
       BetterPlayerUtils.log("GetDataFromUrl failed: $exception");
       return null;
     }


### PR DESCRIPTION
Some methods (http package) throws an error, not an exception so the package doesn't catch it and the app crashes.